### PR TITLE
ci: fix Dependabot prefix + ignore major-version bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,8 +10,11 @@ updates:
       timezone: "America/New_York"
     open-pull-requests-limit: 10
     commit-message:
-      prefix: "deps"
-      prefix-development: "deps-dev"
+      # Type must be a single word (no hyphens) for the
+      # conventional-commits parser used by PR Lint.
+      # `include: "scope"` adds `(deps)` / `(deps-dev)` automatically,
+      # so we still distinguish prod vs dev in the scope.
+      prefix: "chore"
       include: "scope"
     labels:
       - "dependencies"
@@ -20,6 +23,11 @@ updates:
       - "pdugan20"
     reviewers:
       - "pdugan20"
+    # Skip major-version bumps — they're rarely a no-op merge and tend to
+    # break ts-node / CI in ways that need a human. Upgrade majors manually.
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
     # Group minor and patch updates to reduce PR noise
     groups:
       dev-dependencies:

--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -14,6 +14,10 @@ jobs:
     steps:
       - uses: amannn/action-semantic-pull-request@v6
         with:
+          # Type must match [a-zA-Z]+ — no hyphens. The conventional-commits
+          # parser rejects hyphenated types regardless of this allowlist, so
+          # Dependabot is configured to use `chore(deps)` / `chore(deps-dev)`
+          # (hyphen lives in the scope, which is fine).
           types: |
             feat
             fix
@@ -26,7 +30,6 @@ jobs:
             ci
             chore
             deps
-            deps-dev
           requireScope: false
           subjectPattern: ^[a-z].*$
           subjectPatternError: |


### PR DESCRIPTION
## Summary

- Switches Dependabot npm `commit-message.prefix` from `deps` (with `prefix-development: "deps-dev"`) to `chore` + `include: scope`. Result: titles become `chore(deps):` / `chore(deps-dev):`, which the conventional-commits parser used by PR Lint actually accepts (the parser only allows `[a-zA-Z]+` in the type slot — hyphens like `deps-dev` are rejected regardless of the action's `types:` allowlist).
- Adds `ignore: version-update:semver-major` so Dependabot stops opening PRs for major-version bumps that need a human (TS 6, eslint 10, knip 6, etc. all break ts-node / lint configs).
- Removes `deps-dev` from the PR Lint `types:` allowlist (it never actually worked).

## Why now

9 stale Dependabot PRs were stuck on PR Lint failures with the same root cause — see closed #64, #66, #79, #91, #100, #101, #102, #106, #107. The same `prefix-development: "deps-dev"` config was also found in 6 other pdugan20 repos (rss-feed-generator, claudenotes, passant-prototype, libby-downloader, x-archive, e-ink-scoreboard) — those have been updated to match.

## Test plan

- [ ] CI passes on this PR
- [ ] Next Dependabot run opens PRs with `chore(deps):` / `chore(deps-dev):` titles and PR Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)