### PR TITLE
feat: distribute plugin as a downloadable archive for claude --plugin-url

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -238,6 +238,9 @@ jobs:
       - name: Check metadata consistency
         run: npm run test:skills:metadata
 
+      - name: Verify plugin archive packages
+        run: npm run package:plugin
+
   integration:
     name: Integration Tests
     needs: [build]

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -71,6 +71,12 @@ jobs:
         run: npm run package:plugin
 
       - name: Create GitHub Release
-        run: gh release create "${{ github.ref_name }}" --title "${{ github.ref_name }}" --notes-file release-notes.md claudelint-plugin.zip
+        run: |
+          # A pre-release tag (e.g. v1.2.3-beta.0) must be flagged so it
+          # does not become "latest" — the plugin trial docs point users
+          # at /releases/latest/download/claudelint-plugin.zip.
+          PRERELEASE=
+          case "${{ github.ref_name }}" in *-*) PRERELEASE=--prerelease ;; esac
+          gh release create "${{ github.ref_name }}" --title "${{ github.ref_name }}" --notes-file release-notes.md $PRERELEASE claudelint-plugin.zip
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -64,7 +64,13 @@ jobs:
             found { print }
           ' CHANGELOG.md > release-notes.md
 
+      # Bundle .claude-plugin/ + skills/ into claudelint-plugin.zip and
+      # attach it to the release so users can trial the plugin via
+      # `claude --plugin-url` without registering the marketplace.
+      - name: Package plugin archive
+        run: npm run package:plugin
+
       - name: Create GitHub Release
-        run: gh release create "${{ github.ref_name }}" --title "${{ github.ref_name }}" --notes-file release-notes.md
+        run: gh release create "${{ github.ref_name }}" --title "${{ github.ref_name }}" --notes-file release-notes.md claudelint-plugin.zip
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@ node_modules/
 dist/
 *.tgz
 
+# Plugin archive (built by npm run package:plugin, attached to releases)
+claudelint-plugin.zip
+
 # IDE
 .vscode/
 .idea/

--- a/README.md
+++ b/README.md
@@ -40,6 +40,14 @@ Inside Claude Code, add the marketplace and install the plugin:
 
 Or run `claudelint install-plugin` for guided setup.
 
+To trial the plugin for a single session without registering the marketplace (requires Claude Code v2.1.129+):
+
+```bash
+claude --plugin-url https://github.com/pdugan20/claudelint/releases/latest/download/claudelint-plugin.zip
+```
+
+The plugin's skills run the `claudelint` CLI, so install the npm package first either way.
+
 See the [Plugin Guide](https://claudelint.com/integrations/claude-code-plugin) for team setup, plugin scopes, and troubleshooting.
 
 ## What It Checks

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -3,7 +3,7 @@
 The npm release happens in two places:
 
 - **Locally** — `release-it` runs lint/test/build, bumps the version, generates the CHANGELOG entry, syncs versions to plugin/marketplace files, commits, tags, and pushes.
-- **In CI** — `.github/workflows/publish.yml` triggers on the tag push, publishes to npm with OIDC trusted publishing + provenance, then creates a GitHub Release from the CHANGELOG entry.
+- **In CI** — `.github/workflows/publish.yml` triggers on the tag push, publishes to npm with OIDC trusted publishing + provenance, then creates a GitHub Release from the CHANGELOG entry. The release also gets `claudelint-plugin.zip` attached (`npm run package:plugin`) so users can trial the plugin via `claude --plugin-url` without registering the marketplace.
 
 ## Normal release
 
@@ -73,6 +73,7 @@ After CI completes:
 npm view claude-code-lint@<version> dist          # should show attestations.provenance + signatures
 npm view claude-code-lint dist-tags               # latest should match the new version
 gh release view v<version>                        # GitHub release exists
+gh release view v<version> --json assets --jq '.assets[].name'   # lists claudelint-plugin.zip
 ```
 
 If `dist-tags.latest` did not auto-update (rare but seen with v0.4.0):

--- a/package.json
+++ b/package.json
@@ -118,6 +118,7 @@
     "release:rc": "GITHUB_TOKEN=${GITHUB_TOKEN:-$(gh auth token)} release-it --preRelease=rc",
     "sync:versions": "ts-node scripts/util/sync-versions.ts",
     "sync:versions:check": "ts-node scripts/check/version-sync.ts",
+    "package:plugin": "bash scripts/util/package-plugin.sh",
     "setup:hooks": "bash scripts/util/setup-hooks.sh",
     "prepare": "bash scripts/util/setup-hooks.sh || true",
     "prepublishOnly": "npm run build"

--- a/scripts/util/package-plugin.sh
+++ b/scripts/util/package-plugin.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+#
+# Package the Claude Code plugin into a distributable .zip archive.
+#
+# The archive bundles `.claude-plugin/` and `skills/` at its root, which
+# is the layout `claude --plugin-url <url>` expects. It is attached to
+# each GitHub Release by .github/workflows/publish.yml so users can trial
+# the plugin for a session without registering the marketplace.
+#
+# Note: the archived plugin's skills shell out to the `claudelint` CLI,
+# so a --plugin-url trial still requires `npm install -g claude-code-lint`.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+OUT="claudelint-plugin.zip"
+
+rm -f "$OUT"
+
+# `.claude-plugin` is a dotfile but is included because it is named
+# explicitly. `-x` drops macOS cruft so local runs match CI output.
+zip -r -q "$OUT" .claude-plugin skills -x '*.DS_Store'
+
+# Fail loudly if the archive is missing the manifest --plugin-url needs.
+# `grep -c` (not -q) reads all input, so it can't SIGPIPE `unzip` under
+# `pipefail`; `|| true` keeps a zero count from tripping `set -e`.
+manifest_count=$(unzip -Z1 "$OUT" | grep -cx '\.claude-plugin/plugin\.json' || true)
+if [[ "$manifest_count" -eq 0 ]]; then
+  echo "ERROR: $OUT does not contain .claude-plugin/plugin.json" >&2
+  exit 1
+fi
+
+echo "Created $OUT ($(du -h "$OUT" | cut -f1))"

--- a/website/integrations/claude-code-plugin.md
+++ b/website/integrations/claude-code-plugin.md
@@ -19,6 +19,18 @@ The plugin's skills run claudelint CLI commands under the hood. Install the npm 
 
 **Global** makes `claudelint` available in every project. **Project-local** pins a version for your team via `package.json`. See [Global vs Project Install](#global-vs-project-install) for help choosing.
 
+### Quick Trial
+
+To try the plugin for a single session without registering the marketplace, point Claude Code at the release archive:
+
+```bash
+claude --plugin-url https://github.com/pdugan20/claudelint/releases/latest/download/claudelint-plugin.zip
+```
+
+This loads the plugin's skills for the current session only — nothing is persisted and your installed marketplaces are untouched. The skills still run the `claudelint` CLI, so the npm package above is required.
+
+Requires Claude Code v2.1.129 or newer, when the `--plugin-url` flag was added. For a persistent install, use the marketplace below.
+
 ### From the Marketplace
 
 1. Add the marketplace (one-time setup):


### PR DESCRIPTION
## Summary

Adds a release-attached `claudelint-plugin.zip` so users can trial the
claudelint plugin for a single session via `claude --plugin-url <url>`
without registering the marketplace.

The archive bundles `.claude-plugin/` and `skills/` at its root — the
layout `--plugin-url`/`--plugin-dir` expect (a "plugin directory" is the
directory that directly contains `.claude-plugin/plugin.json`).

## Changes

- **`scripts/util/package-plugin.sh`** + `npm run package:plugin` — builds
  the archive and asserts it contains `.claude-plugin/plugin.json`.
- **`publish.yml`** — the `github-release` job packages the archive and
  attaches it to each GitHub Release. Pre-release tags (`-beta`/`-rc`) are
  now flagged `--prerelease` so they don't hijack the
  `releases/latest/download/` URL the trial docs advertise.
- **`ci.yml`** — `skill-validation` job verifies the archive packages on
  every PR.
- **Docs** — README, plugin guide, and `releasing.md` document the trial
  flow, and state plainly that it still requires `npm install -g
  claude-code-lint` (the plugin's skills shell out to the CLI).
- **`.gitignore`** — ignores `claudelint-plugin.zip`.

## Notes

- The `releases/latest/download/claudelint-plugin.zip` URL in the docs
  resolves only once a release after this merge ships the asset. To make
  it live sooner, `gh release upload v0.5.0 claudelint-plugin.zip`.
- Verified: archive extracts to a structurally valid plugin
  (`claudelint check-all` → no problems); zip layout confirmed against
  the official Claude Code plugin docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)