### PR TITLE
docs: drop hardcoded Claude Code version note from --plugin-url trial

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Inside Claude Code, add the marketplace and install the plugin:
 
 Or run `claudelint install-plugin` for guided setup.
 
-To trial the plugin for a single session without registering the marketplace (requires Claude Code v2.1.129+):
+To trial the plugin for a single session without registering the marketplace:
 
 ```bash
 claude --plugin-url https://github.com/pdugan20/claudelint/releases/latest/download/claudelint-plugin.zip

--- a/website/integrations/claude-code-plugin.md
+++ b/website/integrations/claude-code-plugin.md
@@ -29,7 +29,7 @@ claude --plugin-url https://github.com/pdugan20/claudelint/releases/latest/downl
 
 This loads the plugin's skills for the current session only — nothing is persisted and your installed marketplaces are untouched. The skills still run the `claudelint` CLI, so the npm package above is required.
 
-Requires Claude Code v2.1.129 or newer, when the `--plugin-url` flag was added. For a persistent install, use the marketplace below.
+For a persistent install, use the marketplace below.
 
 ### From the Marketplace
 


### PR DESCRIPTION
## Summary

Removes the `Requires Claude Code v2.1.129+` note from the `--plugin-url`
trial instructions in the README and the plugin guide.

Claude Code auto-updates by default, so the release that added
`--plugin-url` is moot for nearly all users within days of its release.
A hardcoded version number in docs just becomes stale cruft.

The session-only vs. persistent-install guidance is kept — that point is
not version-dependent and is genuinely useful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)