### PR TITLE
docs: point plugin install at pdugan20-plugins marketplace

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Use claudelint as a Claude Code plugin for interactive validation via slash comm
 Inside Claude Code, add the marketplace and install the plugin:
 
 ```text
-/plugin marketplace add pdugan20/claudelint
+/plugin marketplace add pdugan20/pdugan20-plugins
 /plugin install claudelint@pdugan20-plugins
 ```
 


### PR DESCRIPTION
The canonical plugin catalog now lives in the dedicated pdugan20/pdugan20-plugins
repo. The install command is unchanged since the marketplace name is the same.
