### PR TITLE
fix: replace invented sandbox/marketplace fields with the documented ones

### DIFF
--- a/src/validators/schemas.ts
+++ b/src/validators/schemas.ts
@@ -116,24 +116,76 @@ export const AttributionSchema = z.object({
 
 /**
  * Sandbox network schema for settings
+ *
+ * Every field below is a row in the `sandbox` table at docs-baseline/settings.md:376-402.
+ *
+ * claudelint previously modelled exactly two fields here, and BOTH were invented:
+ *   - `allowedHosts`  -- the documented field is `allowedDomains`
+ *   - `allowedPorts`  -- no such concept; the ports upstream exposes are
+ *                        `httpProxyPort` / `socksProxyPort`
+ *
+ * That is worse than modelling nothing. `SettingsSchema` is non-strict, so unknown keys are
+ * stripped silently: a user writing the REAL `allowedDomains` got no validation at all,
+ * while a user writing the INVENTED `allowedHosts` got a clean bill of health for a key
+ * Claude Code ignores entirely.
  */
 export const SandboxNetworkSchema = z.object({
-  allowedHosts: z.array(z.string()).optional(),
-  allowedPorts: z.array(z.number()).optional(),
+  allowUnixSockets: z.array(z.string()).optional(),
+  allowAllUnixSockets: z.boolean().optional(),
+  allowLocalBinding: z.boolean().optional(),
+  allowMachLookup: z.array(z.string()).optional(),
+  allowedDomains: z.array(z.string()).optional(),
+  deniedDomains: z.array(z.string()).optional(),
+  allowManagedDomainsOnly: z.boolean().optional(),
+  httpProxyPort: z.number().optional(),
+  socksProxyPort: z.number().optional(),
+  // Experimental. Documented as an object: "Set `{}` to generate an ephemeral certificate".
+  tlsTerminate: z.record(z.string(), z.unknown()).optional(),
+});
+
+/**
+ * Sandbox filesystem schema for settings (documented, never modelled)
+ */
+export const SandboxFilesystemSchema = z.object({
+  allowWrite: z.array(z.string()).optional(),
+  denyWrite: z.array(z.string()).optional(),
+  denyRead: z.array(z.string()).optional(),
+  allowRead: z.array(z.string()).optional(),
+  allowManagedReadPathsOnly: z.boolean().optional(),
+});
+
+/**
+ * Sandbox credentials schema for settings (documented, never modelled)
+ *
+ * `deny` is the only supported mode for files; env vars additionally support `mask`.
+ */
+export const SandboxCredentialsSchema = z.object({
+  files: z.array(z.object({ path: z.string(), mode: z.enum(['deny']) })).optional(),
+  envVars: z.array(z.object({ name: z.string(), mode: z.enum(['deny', 'mask']) })).optional(),
+  allowPlaintextInject: z.boolean().optional(),
 });
 
 /**
  * Sandbox schema for settings
- * Based on official Claude Code sandbox configuration
+ * Based on the `sandbox` table at docs-baseline/settings.md:376-402.
  */
 export const SandboxSchema = z.object({
   enabled: z.boolean().optional(),
+  failIfUnavailable: z.boolean().optional(),
   autoAllowBashIfSandboxed: z.boolean().optional(),
   excludedCommands: z.array(z.string()).optional(),
-  allowUnsandboxedCommands: z.array(z.string()).optional(),
+
+  // A BOOLEAN, not a list of commands: "Allow commands to run outside the sandbox via the
+  // `dangerouslyDisableSandbox` parameter. When set to `false`, the escape hatch is
+  // completely disabled... Default: true". Modelled as `string[]`, this rejected the
+  // documented usage outright -- `"allowUnsandboxedCommands": false` errored with
+  // "expected array, received boolean".
+  allowUnsandboxedCommands: z.boolean().optional(),
+
+  filesystem: SandboxFilesystemSchema.optional(),
+  credentials: SandboxCredentialsSchema.optional(),
   network: SandboxNetworkSchema.optional(),
   enableWeakerNestedSandbox: z.boolean().optional(),
-  ignoreViolations: z.boolean().optional(),
 });
 
 /**
@@ -153,6 +205,7 @@ export const MarketplaceSourceSchema = z.object({
   package: z.string().optional(), // npm
   path: z.string().optional(), // github (subdir), git (subdir), directory, file
   ref: z.string().optional(), // github, git (branch/tag/SHA)
+  skipLfs: z.boolean().optional(), // github, git -- skip Git LFS downloads (v2.1.153+)
   name: z.string().optional(), // settings (inline marketplace)
   // z.lazy: MarketplacePluginEntrySchema is declared further down this module. An inline
   // marketplace's plugin entries are the same shape as a hosted marketplace.json's, so
@@ -162,10 +215,17 @@ export const MarketplaceSourceSchema = z.object({
 
 /**
  * Marketplace config schema for settings (extraKnownMarketplaces entries)
+ *
+ * The entry toggle is `autoUpdate`, not `enabled`: "Each marketplace entry also accepts an
+ * optional `autoUpdate` Boolean... When omitted, official Anthropic marketplaces default to
+ * `true` and all other marketplaces default to `false`" (docs-baseline/settings.md:821).
+ * `enabled` appears nowhere on a marketplace entry -- it was invented.
+ *
+ * Also documented on the source object for `github` and `git`: `skipLfs`.
  */
 export const MarketplaceConfigSchema = z.object({
   source: MarketplaceSourceSchema,
-  enabled: z.boolean().optional(),
+  autoUpdate: z.boolean().optional(),
 });
 
 /**

--- a/tests/schemas/settings.schema.test.ts
+++ b/tests/schemas/settings.schema.test.ts
@@ -8,6 +8,7 @@ import {
   AttributionSchema,
   SandboxSchema,
   SettingsHooksSchema,
+  MarketplaceConfigSchema,
 } from '../../src/validators/schemas';
 
 describe('SettingsSchema', () => {
@@ -283,37 +284,83 @@ describe('SandboxSchema', () => {
     expect(result.success).toBe(true);
   });
 
-  it('should accept allowUnsandboxedCommands array', () => {
-    const result = SandboxSchema.safeParse({
-      enabled: true,
-      allowUnsandboxedCommands: ['docker', 'brew'],
-    });
-    expect(result.success).toBe(true);
+  it('accepts allowUnsandboxedCommands as a BOOLEAN', () => {
+    // Documented as a boolean: "Allow commands to run outside the sandbox via the
+    // `dangerouslyDisableSandbox` parameter. When set to `false`, the escape hatch is
+    // completely disabled... Default: true" (docs-baseline/settings.md).
+    // It was modelled as `string[]`, so the documented usage errored with
+    // "expected array, received boolean". This test asserted the wrong type.
+    expect(SandboxSchema.safeParse({ allowUnsandboxedCommands: false }).success).toBe(true);
+    expect(SandboxSchema.safeParse({ allowUnsandboxedCommands: ['docker'] }).success).toBe(false);
   });
 
-  it('should accept network config', () => {
+  it('should accept network config with the DOCUMENTED field names', () => {
     const result = SandboxSchema.safeParse({
       enabled: true,
       network: {
-        allowedHosts: ['api.example.com'],
-        allowedPorts: [443, 8080],
+        allowedDomains: ['github.com', '*.npmjs.org'],
+        deniedDomains: ['sensitive.cloud.example.com'],
+        httpProxyPort: 8080,
+        socksProxyPort: 8081,
+        allowManagedDomainsOnly: true,
       },
     });
     expect(result.success).toBe(true);
   });
 
+  it('does not model the invented network fields', () => {
+    // `allowedHosts` and `allowedPorts` were both fabricated -- the real fields are
+    // `allowedDomains` and `httpProxyPort`/`socksProxyPort`. The schema is non-strict, so
+    // parsing still succeeds; what must be true is that these are STRIPPED rather than
+    // modelled, so claudelint never blesses a key Claude Code ignores.
+    const result = SandboxSchema.parse({
+      network: { allowedHosts: ['api.example.com'], allowedPorts: [443] },
+    });
+
+    expect(result.network).toEqual({});
+  });
+
+  it('does not model the invented ignoreViolations field', () => {
+    // Appears nowhere in the docs.
+    expect(SandboxSchema.parse({ ignoreViolations: true })).toEqual({});
+  });
+
   it('should accept enableWeakerNestedSandbox', () => {
+    // NOT a hallucination -- this one IS documented. Verified before touching it.
     const result = SandboxSchema.safeParse({
       enableWeakerNestedSandbox: true,
     });
     expect(result.success).toBe(true);
   });
 
-  it('should accept ignoreViolations', () => {
+  it('accepts the documented filesystem subtree', () => {
     const result = SandboxSchema.safeParse({
-      ignoreViolations: true,
+      filesystem: {
+        allowWrite: ['/tmp/build', '~/.kube'],
+        denyRead: ['~/.aws/credentials'],
+        allowManagedReadPathsOnly: true,
+      },
     });
     expect(result.success).toBe(true);
+  });
+
+  it('accepts the documented credentials subtree', () => {
+    const result = SandboxSchema.safeParse({
+      credentials: {
+        files: [{ path: '~/.aws/credentials', mode: 'deny' }],
+        envVars: [{ name: 'GITHUB_TOKEN', mode: 'deny' }],
+        allowPlaintextInject: true,
+      },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects an unsupported credential file mode', () => {
+    // `deny` is the only supported mode for files; `mask` is env-vars-only.
+    const result = SandboxSchema.safeParse({
+      credentials: { files: [{ path: '~/.aws/credentials', mode: 'mask' }] },
+    });
+    expect(result.success).toBe(false);
   });
 
   it('should accept all fields optional', () => {
@@ -324,15 +371,18 @@ describe('SandboxSchema', () => {
   it('should accept full sandbox configuration', () => {
     const result = SandboxSchema.safeParse({
       enabled: true,
+      failIfUnavailable: true,
       autoAllowBashIfSandboxed: true,
-      excludedCommands: ['rm -rf'],
-      allowUnsandboxedCommands: ['docker'],
+      excludedCommands: ['docker *'],
+      allowUnsandboxedCommands: false,
+      filesystem: { allowWrite: ['/tmp/build'] },
+      credentials: { envVars: [{ name: 'GITHUB_TOKEN', mode: 'deny' }] },
       network: {
-        allowedHosts: ['localhost'],
-        allowedPorts: [3000],
+        allowedDomains: ['github.com'],
+        httpProxyPort: 8080,
+        tlsTerminate: {},
       },
       enableWeakerNestedSandbox: false,
-      ignoreViolations: false,
     });
     expect(result.success).toBe(true);
   });
@@ -426,6 +476,38 @@ describe('SettingsHooksSchema', () => {
           ],
         },
       ],
+    });
+    expect(result.success).toBe(true);
+  });
+});
+
+describe('MarketplaceConfigSchema', () => {
+  it('models autoUpdate, the documented entry toggle', () => {
+    // "Each marketplace entry also accepts an optional `autoUpdate` Boolean... official
+    // Anthropic marketplaces default to `true` and all other marketplaces default to
+    // `false`" (docs-baseline/settings.md:821).
+    const result = MarketplaceConfigSchema.safeParse({
+      source: { source: 'github', repo: 'acme/plugins' },
+      autoUpdate: true,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('does not model the invented `enabled` toggle', () => {
+    // `enabled` appears nowhere on a marketplace entry. The schema is non-strict, so the
+    // parse succeeds -- what matters is that the key is STRIPPED, not modelled, so
+    // claudelint never blesses a toggle Claude Code ignores.
+    const result = MarketplaceConfigSchema.parse({
+      source: { source: 'github', repo: 'acme/plugins' },
+      enabled: true,
+    });
+
+    expect(result).not.toHaveProperty('enabled');
+  });
+
+  it('accepts skipLfs on a git-backed source', () => {
+    const result = MarketplaceConfigSchema.safeParse({
+      source: { source: 'github', repo: 'acme/plugins', skipLfs: true },
     });
     expect(result.success).toBe(true);
   });


### PR DESCRIPTION
Phase 2 of #132 — the "probable hallucinations". Every claim is checked against the `sandbox` table at `docs-baseline/settings.md:376-402` and the marketplace prose at `settings.md:821`, per the issue's ground rule: **do not add or remove a schema field on inference.**

## Confirmed invented — removed

| Field | The documented field |
|---|---|
| `sandbox.network.allowedHosts` | `allowedDomains` |
| `sandbox.network.allowedPorts` | no such concept — `httpProxyPort` / `socksProxyPort` |
| `sandbox.ignoreViolations` | appears nowhere in the docs |
| marketplace entry `enabled` | `autoUpdate` |

## NOT invented — kept

**`sandbox.enableWeakerNestedSandbox` is documented.** The audit didn't clear it, and it fits the pattern of the other four perfectly. Deleting it on that basis would have repeated the `disallowed-tools` mistake this project has already made once — which is exactly why the ground rule exists. I checked.

## Why removing a fake field matters even though it caused no error

`SettingsSchema` is non-strict, so unknown keys are stripped silently. That cuts a way people don't expect:

- a user writing the **real** `allowedDomains` got **no validation at all** (stripped),
- a user writing the **invented** `allowedHosts` got a **clean bill of health** for a key Claude Code ignores entirely.

Modelling a fabricated field is worse than modelling none: it actively blesses config that does nothing.

## A false positive nobody had found

**`sandbox.allowUnsandboxedCommands` is a boolean**, not a list of commands:

> "Allow commands to run outside the sandbox via the `dangerouslyDisableSandbox` parameter. When set to `false`, the escape hatch is completely disabled and all commands must run sandboxed... **Default: true**"

Modelled as `string[]`, so the documented usage was rejected outright:

```console
$ cat .claude/settings.json
{"sandbox":{"enabled":true,"allowUnsandboxedCommands":false}}

.claude/settings.json (1 error)
  0  error  sandbox.allowUnsandboxedCommands: Invalid input: expected array, received boolean
```

Worth noting **why neither existing gate caught this**, because it points at the next one to build:

- `check:upstream` compares **field names**. `allowUnsandboxedCommands` is present in both the docs and the schema, so it reads as conformant.
- The docs-example gate (#136) lints every **example**. No example uses this field — it is documented only in the **field table**.

Neither gate reads the *types* in the tables. That's the third gate, and it's the natural Phase 3 companion to registering `SettingsSchema`.

## Also: the documented surface that was never modelled

Removing the fakes must not leave users with *less* validation than before, so this also models what upstream actually documents: `sandbox.filesystem.*`, `sandbox.credentials.*` (including the `deny`-only mode on files vs `deny`/`mask` on env vars), the full `sandbox.network.*` surface, `failIfUnavailable`, and `skipLfs` on a git-backed marketplace source.

Verified end-to-end — this config errored before and lints clean now:

```json
{"sandbox":{"enabled":true,"allowUnsandboxedCommands":false,
  "network":{"allowedDomains":["github.com"],"httpProxyPort":8080}}}
```

## Tests

Tests that asserted the invented shape are inverted, and the fabricated keys are now pinned as **not modelled** — asserted to be *stripped* rather than blessed — so they cannot creep back:

```ts
expect(SandboxSchema.parse({ network: { allowedHosts: ['x'], allowedPorts: [443] } }).network).toEqual({});
expect(SandboxSchema.parse({ ignoreViolations: true })).toEqual({});
```

- 1932 tests / 211 suites green
- The docs-example gate from #136 still green (86/86)
- `check:self`, `check:upstream`, `check:schema-sync`, `check:all`, `docs:build` — all green

## Follow-up worth doing

`SettingsSchema` is still **not in `SCHEMA_REGISTRY`**, so none of this is enforceable: no settings JSON schema is published, `check:schema-sync` doesn't cover it, and `settings.md`'s watchlist entry has `governs: []` — its 162 facts assert nothing. That's Phase 3, and it's what would have caught all five of these automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RLcJgHCxxsifDhJck6C8xb