### PR TITLE
test(upstream): gate schema field types against the documented examples

### DIFF
--- a/scripts/upstream/field-types.ts
+++ b/scripts/upstream/field-types.ts
@@ -1,0 +1,142 @@
+/**
+ * Type conformance: do claudelint's schemas ACCEPT the values the docs print?
+ *
+ * The third gate, and the seam the first two leave open.
+ *
+ *   - `check:upstream` compares field NAMES. `allowUnsandboxedCommands` is present in both
+ *     the docs and the schema, so a name diff calls it conformant -- while the docs say it
+ *     is a boolean and claudelint demanded a `string[]`.
+ *   - The docs-example gate (tests/upstream/docs-examples.test.ts) lints whole EXAMPLES.
+ *     No example uses that field; it is documented only in a table.
+ *
+ * Neither reads the types in the tables. This does, and it does it without inventing a type
+ * system: every settings table upstream publishes carries an **Example** column, and a value
+ * the docs print as the example for a field is, by definition, a valid value for that field.
+ * So build `{ sandbox: { allowUnsandboxedCommands: false } }` from the row and parse it. If
+ * the schema rejects it, claudelint is wrong -- not the docs.
+ *
+ * Rows are relative to the object their section documents, so SECTION_BINDINGS says which
+ * settings key each table hangs under. A section we cannot bind is skipped rather than
+ * guessed at; MIN_TYPED_FIELDS is what stops "skipped" from quietly becoming "all of them".
+ */
+
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+export interface FieldExample {
+  /** Settings key the row's table hangs under, e.g. `sandbox`. Empty for top-level. */
+  section: string;
+  /** Field path within that section, e.g. `network.allowedDomains`. */
+  field: string;
+  /** The value the docs print in the Example column, parsed. */
+  example: unknown;
+  /** 1-based line of the table row, for a clickable failure. */
+  line: number;
+}
+
+/**
+ * Which settings key each documented table hangs under.
+ *
+ * Only sections whose binding is unambiguous. `### Available settings` is deliberately
+ * absent: its rows are top-level and mix scalars with deep objects whose Example cells are
+ * abridged, so binding it would manufacture failures rather than find them.
+ */
+export const SECTION_BINDINGS: Record<string, string> = {
+  'Sandbox settings': 'sandbox',
+  'Permission settings': 'permissions',
+  'Attribution settings': 'attribution',
+};
+
+/**
+ * Below this, assume the table parser broke rather than that upstream deleted its tables.
+ * Never lower this to make a red build pass.
+ */
+export const MIN_TYPED_FIELDS = 20;
+
+/**
+ * Parse the Example cell into a real value.
+ *
+ * Returns `undefined` when the cell is not a self-contained literal -- prose, an ellipsis,
+ * a `<placeholder>`. Those are skipped: a cell we cannot parse is not evidence of anything,
+ * and pretending otherwise would produce phantom findings.
+ */
+export function parseExample(cell: string): unknown {
+  const trimmed = cell.trim().replace(/^`|`$/g, '').trim();
+  if (!trimmed) return undefined;
+
+  try {
+    return JSON.parse(trimmed);
+  } catch {
+    return undefined;
+  }
+}
+
+/** Section heading -> settings key, for the heading currently in effect. */
+function sectionFor(heading: string | null): string | null {
+  if (!heading) return null;
+  return SECTION_BINDINGS[heading] ?? null;
+}
+
+/**
+ * Table rows with a parseable Example cell, grouped under the section they appear in.
+ *
+ * Matches `| \`field\` | description | \`example\` |` -- three cells, first backtick-quoted.
+ * A dotted first cell (`network.allowedDomains`) is a nested path within the section.
+ */
+export function extractFieldExamples(markdown: string): FieldExample[] {
+  const out: FieldExample[] = [];
+  const lines = markdown.split('\n');
+  let heading: string | null = null;
+
+  for (let i = 0; i < lines.length; i++) {
+    const headingMatch = /^#{2,4}\s+(.+?)\s*$/.exec(lines[i]);
+    if (headingMatch) {
+      heading = headingMatch[1];
+      continue;
+    }
+
+    const section = sectionFor(heading);
+    if (section === null) continue;
+
+    // `| `field` | ... | `example` |`
+    const row = /^\|\s*`([A-Za-z][A-Za-z0-9_.-]*)`\s*\|(.*)\|([^|]*)\|\s*$/.exec(lines[i]);
+    if (!row) continue;
+
+    const example = parseExample(row[3]);
+    if (example === undefined) continue;
+
+    out.push({ section, field: row[1], example, line: i + 1 });
+  }
+
+  return out;
+}
+
+/** Build the minimal settings document that places `example` at `section.field`. */
+export function toSettingsDocument(entry: FieldExample): Record<string, unknown> {
+  const path = entry.field.split('.');
+  const leaf: Record<string, unknown> = {};
+
+  let cursor = leaf;
+  for (let i = 0; i < path.length - 1; i++) {
+    const next: Record<string, unknown> = {};
+    cursor[path[i]] = next;
+    cursor = next;
+  }
+  cursor[path[path.length - 1]] = entry.example;
+
+  return entry.section ? { [entry.section]: leaf } : leaf;
+}
+
+export function loadSettingsDoc(baselineDir: string): string {
+  return readFileSync(join(baselineDir, 'settings.md'), 'utf8');
+}
+
+export function assertMinTypedFields(count: number): void {
+  if (count < MIN_TYPED_FIELDS) {
+    throw new Error(
+      `Type-conformance guard tripped: only ${count} documented field examples were parsed ` +
+        `(floor: ${MIN_TYPED_FIELDS}). Upstream likely restyled its settings tables. Fix the ` +
+        `parser - do not lower MIN_TYPED_FIELDS to make this pass.`
+    );
+  }
+}

--- a/tests/upstream/field-types.test.ts
+++ b/tests/upstream/field-types.test.ts
@@ -1,0 +1,124 @@
+import { join } from 'path';
+import { SettingsSchema } from '../../src/validators/schemas';
+import {
+  extractFieldExamples,
+  toSettingsDocument,
+  parseExample,
+  assertMinTypedFields,
+  loadSettingsDoc,
+  MIN_TYPED_FIELDS,
+  type FieldExample,
+} from '../../scripts/upstream/field-types';
+
+/**
+ * Every value the docs print as a field's Example must parse against claudelint's schema.
+ *
+ * This is the gate the other two structurally cannot be:
+ *
+ *   - `check:upstream` compares field NAMES, so a field present in both the docs and the
+ *     schema reads as conformant even when we demand the wrong TYPE for it.
+ *   - The docs-example gate lints whole documents, and only fields that appear in a
+ *     worked example are covered by it.
+ *
+ * `sandbox.allowUnsandboxedCommands` fell through exactly that seam: documented as a
+ * boolean, modelled as `string[]`, used in no example, and shipped rejecting the documented
+ * usage with "expected array, received boolean". This test is what closes it.
+ */
+
+const BASELINE = join(__dirname, '../../docs-baseline');
+
+function describeFailure(entry: FieldExample, issues: string[]): string {
+  const path = entry.section ? `${entry.section}.${entry.field}` : entry.field;
+
+  return (
+    `\n  docs-baseline/settings.md:${entry.line}\n` +
+    `  claudelint rejects the value the docs print for \`${path}\`:\n` +
+    `    example:  ${JSON.stringify(entry.example)}\n` +
+    `    rejected: ${issues.join('; ')}\n`
+  );
+}
+
+describe('documented field examples parse against the schema', () => {
+  const examples = extractFieldExamples(loadSettingsDoc(BASELINE));
+
+  it('parses field examples out of the settings tables', () => {
+    // If the parser silently degrades toward zero, every assertion below passes vacuously.
+    assertMinTypedFields(examples.length);
+    expect(examples.length).toBeGreaterThanOrEqual(MIN_TYPED_FIELDS);
+  });
+
+  it('the schema actually rejects a wrongly-typed value (anti-vacuity)', () => {
+    // Prove the mechanism bites before trusting a pass. A gate that cannot fail is
+    // decoration -- and this repo has already shipped three of those.
+    const bogus = toSettingsDocument({
+      section: 'sandbox',
+      field: 'enabled',
+      example: 'not-a-boolean',
+      line: 0,
+    });
+
+    expect(SettingsSchema.safeParse(bogus).success).toBe(false);
+  });
+
+  it.each(examples.map((e) => [`${e.section}.${e.field}`, e] as const))(
+    'accepts the documented example for %s',
+    (_label, entry) => {
+      const result = SettingsSchema.safeParse(toSettingsDocument(entry));
+
+      if (!result.success) {
+        throw new Error(
+          describeFailure(
+            entry,
+            result.error.issues.map((i) => `${i.path.join('.')}: ${i.message}`)
+          )
+        );
+      }
+    }
+  );
+});
+
+describe('parseExample', () => {
+  it('parses the literal forms the docs use', () => {
+    expect(parseExample('`true`')).toBe(true);
+    expect(parseExample('`8080`')).toBe(8080);
+    expect(parseExample('`["github.com", "*.npmjs.org"]`')).toEqual(['github.com', '*.npmjs.org']);
+    expect(parseExample('`{}`')).toEqual({});
+    expect(parseExample('`[{ "name": "GITHUB_TOKEN", "mode": "deny" }]`')).toEqual([
+      { name: 'GITHUB_TOKEN', mode: 'deny' },
+    ]);
+  });
+
+  it('skips a cell that is not a self-contained literal', () => {
+    // Prose and placeholders are not evidence of a type. Guessing at them would
+    // manufacture phantom findings, which erodes trust in the gate faster than a missed
+    // field does.
+    expect(parseExample('see below')).toBeUndefined();
+    expect(parseExample('`<your-token>`')).toBeUndefined();
+    expect(parseExample('')).toBeUndefined();
+  });
+});
+
+describe('toSettingsDocument', () => {
+  it('nests a dotted field under its section', () => {
+    expect(
+      toSettingsDocument({
+        section: 'sandbox',
+        field: 'network.allowedDomains',
+        example: ['github.com'],
+        line: 0,
+      })
+    ).toEqual({ sandbox: { network: { allowedDomains: ['github.com'] } } });
+  });
+
+  it('places a flat field directly under its section', () => {
+    expect(
+      toSettingsDocument({ section: 'sandbox', field: 'enabled', example: true, line: 0 })
+    ).toEqual({ sandbox: { enabled: true } });
+  });
+});
+
+describe('assertMinTypedFields', () => {
+  it('throws when the table parser yields almost nothing', () => {
+    expect(() => assertMinTypedFields(0)).toThrow(/Type-conformance guard tripped/);
+  });
+});


### PR DESCRIPTION
Phase 3 of #132 — the third gate, and the seam the first two leave open.

## The seam

`sandbox.allowUnsandboxedCommands` shipped rejecting the documented usage (`false` → *"expected array, received boolean"*). Both existing gates were green:

| Gate | What it compares | Why it missed this |
|---|---|---|
| `check:upstream` | field **names** | the field is in both the docs and the schema — reads conformant |
| docs-example gate (#136) | whole **examples** | no example uses the field; it's documented only in a table row |

**Neither reads the types in the tables.** This does.

## How, without inventing a type system

Every settings table upstream publishes carries an **Example** column. A value the docs print as the example for a field is, by definition, a valid value for that field. So build the minimal document from the row and parse it:

```
| `allowUnsandboxedCommands` | ...prose... | `false` |
        ↓
{ "sandbox": { "allowUnsandboxedCommands": false } }
        ↓
SettingsSchema.safeParse(...)   →  must succeed
```

If the schema rejects it, claudelint is wrong — not the docs. Same principle as #136, applied per-field instead of per-document.

## Proving it bites

A gate that cannot fail is decoration — and this repo has already shipped three of those (a workflow whose detector steps were skipped, three MCP rules keyed to an impossible value, and an API whose tests asserted only the result's shape). So I reintroduced the exact Phase 2 bug and watched it go red:

```text
docs-baseline/settings.md:384
claudelint rejects the value the docs print for `sandbox.allowUnsandboxedCommands`:
  example:  false
  rejected: sandbox.allowUnsandboxedCommands: Invalid input: expected array, received boolean
```

Restore the fix and it's green. It also carries its own anti-vacuity test and a `MIN_TYPED_FIELDS` floor, so a parser that silently stops finding rows fails loudly instead of passing empty.

## Deliberately conservative

Rows are relative to the object their section documents, so `SECTION_BINDINGS` says which settings key each table hangs under (`Sandbox settings` → `sandbox`, etc.).

**`### Available settings` is deliberately unbound.** Its rows are top-level and its Example cells are abridged, so binding it would manufacture phantom failures rather than find real ones — and a gate people learn to ignore is worse than no gate. `MIN_TYPED_FIELDS` is what stops "conservative" from quietly degrading into "skips everything".

## Why `SettingsSchema` registration is NOT in this PR

I recommended registering `SettingsSchema` in `SCHEMA_REGISTRY` first. Having measured it, that order is wrong:

```text
documented top-level settings (table rows): 148
modeled by claudelint:                       27
```

Turning on name-conformance for settings today would go **red immediately** with ~100+ `documented-not-modeled` findings — the entire Phase 4 backlog, arriving as a broken build rather than as a plan. The right order is:

1. **This PR** — type conformance (independent, green today).
2. **Phase 4** — model the documented settings surface.
3. **Then** register `SettingsSchema` + switch on name conformance, which by then lands green and stays green.

## Testing

- 1972 tests / 212 suites green
- `check:upstream`, `check:all`, `lint`, `format` — green
- The gate runs in the existing Test job; no CI wiring needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RLcJgHCxxsifDhJck6C8xb