### PR TITLE
docs: correct the public docs the schema fixes left stale

### DIFF
--- a/docs/projects/upstream-drift-audit.md
+++ b/docs/projects/upstream-drift-audit.md
@@ -1,5 +1,37 @@
 # Upstream Drift Audit — 2026-07-12
 
+> **RESOLVED 2026-07-13. Kept as a record of what the first sweep found, and of what it
+> got wrong. Do not work from the list below — everything in it is shipped, superseded,
+> or corrected.** Tracked in [#132]; shipped in #136, #140, #141, #142, #143.
+>
+> **What shipped**
+>
+> - **9 false positives fixed** — claudelint rejected documented config in nine cases, not
+>   the three this audit identified. Six were found by gates built during the work, not by
+>   this sweep: an agent-hook using `prompt`, `context: fork` without `agent`, a URL with a
+>   `${VAR:-default}`, a marketplace `source: "settings"`, `allowUnsandboxedCommands: false`,
+>   `statusLine` as an object, and `teammateMode` as a string.
+> - **4 invented fields removed**, and `settings.json` coverage went from 23 of 117
+>   documented keys to all of them.
+> - **Three new gates**, each of which caught bugs the others structurally could not see:
+>   whole-document examples (#136), documented example *values* (#141), and key *names* in
+>   both directions (#143).
+>
+> **What this audit got wrong** — worth reading before trusting a future one:
+>
+> - **Severity 1.3 (skill `name` required) does not reproduce.** `skill-name.ts` returns
+>   early before the schema is consulted, so nothing enforced it. Read off the Zod
+>   declaration; never exercised against the CLI.
+> - **`enableWeakerNestedSandbox` was not cleared, and it is documented.** It fits the
+>   hallucination pattern exactly. Deleting it on that basis would have repeated the
+>   `disallowed-tools` mistake — the one this document itself flags in Severity 3.
+> - **The method could not see type drift.** Comparing field *names* against the docs calls
+>   `tools` conformant while the docs' own canonical sub-agent example fails to lint.
+>
+> The lesson is in the shape of the errors, not the count: a field-name diff, read off the
+> schema rather than exercised, is blind both to what a field *accepts* and to whether the
+> code enforces the schema at all.
+
 First full sweep of every claudelint schema against the official Claude Code docs,
 run against the committed `docs-baseline/` snapshot.
 

--- a/src/rules/mcp/mcp-invalid-transport.ts
+++ b/src/rules/mcp/mcp-invalid-transport.ts
@@ -32,9 +32,10 @@ export const rule: Rule = {
         'An unrecognized transport type prevents Claude Code from establishing any connection to the MCP server.',
       details:
         'This rule checks that the type field of each MCP server is one of the supported transport ' +
-        'types: stdio, sse, http, or websocket. An unrecognized transport type will prevent Claude ' +
-        'Code from establishing a connection to the MCP server. Servers without an explicit type ' +
-        'field are skipped because the type can be inferred from the presence of a command field.',
+        'types: stdio, sse, http, streamable-http, or ws. An unrecognized transport type will ' +
+        'prevent Claude Code from establishing a connection to the MCP server. Servers without an ' +
+        'explicit type field are skipped because the type can be inferred from the presence of a ' +
+        'command field.',
       examples: {
         incorrect: [
           {
@@ -57,8 +58,9 @@ export const rule: Rule = {
         ],
       },
       howToFix:
-        'Change the type field to one of the supported values: stdio, sse, http, or websocket. ' +
-        'Note that sse is deprecated in favor of http.',
+        'Change the type field to one of the supported values: stdio, sse, http, streamable-http, ' +
+        'or ws. Note that sse is deprecated in favor of http, and that the WebSocket literal is ' +
+        '"ws" - not "websocket", which is not a valid config value.',
       relatedRules: ['mcp-sse-transport-deprecated'],
     },
   },

--- a/src/rules/mcp/mcp-sse-transport-deprecated.ts
+++ b/src/rules/mcp/mcp-sse-transport-deprecated.ts
@@ -45,7 +45,7 @@ export const rule: Rule = {
           },
           {
             description: 'Server using WebSocket transport',
-            code: '{\n  "mcpServers": {\n    "remote": {\n      "type": "websocket",\n      "url": "wss://mcp.example.com/ws"\n    }\n  }\n}',
+            code: '{\n  "mcpServers": {\n    "remote": {\n      "type": "ws",\n      "url": "wss://mcp.example.com/ws"\n    }\n  }\n}',
             language: 'json',
           },
         ],

--- a/src/rules/mcp/mcp-websocket-empty-url.ts
+++ b/src/rules/mcp/mcp-websocket-empty-url.ts
@@ -31,19 +31,19 @@ export const rule: Rule = {
         incorrect: [
           {
             description: 'WebSocket server with an empty URL string',
-            code: '{\n  "mcpServers": {\n    "realtime": {\n      "type": "websocket",\n      "url": ""\n    }\n  }\n}',
+            code: '{\n  "mcpServers": {\n    "realtime": {\n      "type": "ws",\n      "url": ""\n    }\n  }\n}',
             language: 'json',
           },
           {
             description: 'WebSocket server with the url field missing',
-            code: '{\n  "mcpServers": {\n    "realtime": {\n      "type": "websocket"\n    }\n  }\n}',
+            code: '{\n  "mcpServers": {\n    "realtime": {\n      "type": "ws"\n    }\n  }\n}',
             language: 'json',
           },
         ],
         correct: [
           {
             description: 'WebSocket server with a valid URL',
-            code: '{\n  "mcpServers": {\n    "realtime": {\n      "type": "websocket",\n      "url": "wss://mcp.example.com/ws"\n    }\n  }\n}',
+            code: '{\n  "mcpServers": {\n    "realtime": {\n      "type": "ws",\n      "url": "wss://mcp.example.com/ws"\n    }\n  }\n}',
             language: 'json',
           },
         ],

--- a/src/rules/mcp/mcp-websocket-invalid-protocol.ts
+++ b/src/rules/mcp/mcp-websocket-invalid-protocol.ts
@@ -34,19 +34,19 @@ export const rule: Rule = {
         incorrect: [
           {
             description: 'WebSocket server using https:// instead of wss://',
-            code: '{\n  "mcpServers": {\n    "realtime": {\n      "type": "websocket",\n      "url": "https://mcp.example.com/ws"\n    }\n  }\n}',
+            code: '{\n  "mcpServers": {\n    "realtime": {\n      "type": "ws",\n      "url": "https://mcp.example.com/ws"\n    }\n  }\n}',
             language: 'json',
           },
         ],
         correct: [
           {
             description: 'WebSocket server using wss:// protocol',
-            code: '{\n  "mcpServers": {\n    "realtime": {\n      "type": "websocket",\n      "url": "wss://mcp.example.com/ws"\n    }\n  }\n}',
+            code: '{\n  "mcpServers": {\n    "realtime": {\n      "type": "ws",\n      "url": "wss://mcp.example.com/ws"\n    }\n  }\n}',
             language: 'json',
           },
           {
             description: 'WebSocket server using ws:// protocol for local development',
-            code: '{\n  "mcpServers": {\n    "local": {\n      "type": "websocket",\n      "url": "ws://localhost:8080/ws"\n    }\n  }\n}',
+            code: '{\n  "mcpServers": {\n    "local": {\n      "type": "ws",\n      "url": "ws://localhost:8080/ws"\n    }\n  }\n}',
             language: 'json',
           },
         ],

--- a/src/rules/mcp/mcp-websocket-invalid-url.ts
+++ b/src/rules/mcp/mcp-websocket-invalid-url.ts
@@ -32,19 +32,19 @@ export const rule: Rule = {
         incorrect: [
           {
             description: 'WebSocket server with a malformed URL',
-            code: '{\n  "mcpServers": {\n    "realtime": {\n      "type": "websocket",\n      "url": "not-a-valid-url"\n    }\n  }\n}',
+            code: '{\n  "mcpServers": {\n    "realtime": {\n      "type": "ws",\n      "url": "not-a-valid-url"\n    }\n  }\n}',
             language: 'json',
           },
         ],
         correct: [
           {
             description: 'WebSocket server with a valid URL',
-            code: '{\n  "mcpServers": {\n    "realtime": {\n      "type": "websocket",\n      "url": "wss://mcp.example.com/ws"\n    }\n  }\n}',
+            code: '{\n  "mcpServers": {\n    "realtime": {\n      "type": "ws",\n      "url": "wss://mcp.example.com/ws"\n    }\n  }\n}',
             language: 'json',
           },
           {
             description: 'WebSocket server with a variable-expanded URL (skipped)',
-            code: '{\n  "mcpServers": {\n    "realtime": {\n      "type": "websocket",\n      "url": "${MCP_WS_URL}"\n    }\n  }\n}',
+            code: '{\n  "mcpServers": {\n    "realtime": {\n      "type": "ws",\n      "url": "${MCP_WS_URL}"\n    }\n  }\n}',
             language: 'json',
           },
         ],

--- a/website/api/schemas/agents.md
+++ b/website/api/schemas/agents.md
@@ -1,5 +1,5 @@
 ---
-description: "Schema reference for agent file YAML frontmatter fields, types, and constraints."
+description: 'Schema reference for agent file YAML frontmatter fields, types, and constraints.'
 ---
 
 # Agent Frontmatter
@@ -13,28 +13,29 @@ Agent files are flat `.md` files (e.g., `.claude/agents/code-reviewer.md`). The 
 
 ## Fields
 
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `name` | string | yes | Lowercase with hyphens, max 64 chars |
-| `description` | string | yes | Min 10 chars, third-person voice |
-| `model` | string | no | Alias (`sonnet`, `opus`, `haiku`, `inherit`) or full model ID (e.g. `claude-opus-4-6`) |
-| `tools` | string[] | no | [Tool names](/api/schemas#tool-names) to allow |
-| `disallowedTools` | string[] | no | [Tool names](/api/schemas#tool-names) to disallow |
-| `permissionMode` | string | no | [Permission mode](/api/schemas#permission-modes): `default`, `acceptEdits`, `auto`, `dontAsk`, `bypassPermissions`, or `plan` |
-| `skills` | string[] | no | Skills this agent can use |
-| `hooks` | object | no | [Hooks configuration](/api/schemas/hooks) |
-| `memory` | string | no | `user`, `project`, or `local` |
-| `effort` | string | no | [Effort level](/api/schemas#effort-levels): `low`, `medium`, `high`, `xhigh`, or `max` |
-| `maxTurns` | number | no | Maximum agent turns (positive integer) |
-| `mcpServers` | (string\|object)[] | no | MCP server references or inline definitions |
-| `color` | string | no | [Display color](/api/schemas#agent-colors): `red`, `blue`, `green`, `yellow`, `purple`, `orange`, `pink`, or `cyan` |
-| `background` | boolean | no | Run as background task (default: `false`) |
-| `isolation` | string | no | `worktree` — run in a temporary git worktree |
-| `initialPrompt` | string | no | Auto-submitted as the first user turn when this agent runs as the main session agent (via `--agent` or the `agent` setting). Prepended to any user-provided prompt |
+| Field             | Type               | Required | Description                                                                                                                                                        |
+| ----------------- | ------------------ | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `name`            | string             | yes      | Lowercase with hyphens, max 64 chars                                                                                                                               |
+| `description`     | string             | yes      | Min 10 chars, third-person voice                                                                                                                                   |
+| `model`           | string             | no       | Alias (`sonnet`, `opus`, `haiku`, `inherit`) or full model ID (e.g. `claude-opus-4-6`)                                                                             |
+| `tools`           | string \| string[] | no       | [Tool names](/api/schemas#tool-names) to allow. A space- or comma-separated string (`Read, Glob, Grep`) or a YAML list                                             |
+| `disallowedTools` | string \| string[] | no       | [Tool names](/api/schemas#tool-names) to disallow. Same forms as `tools`                                                                                           |
+| `permissionMode`  | string             | no       | [Permission mode](/api/schemas#permission-modes): `default`, `manual`, `acceptEdits`, `auto`, `dontAsk`, `bypassPermissions`, or `plan`                            |
+| `skills`          | string[]           | no       | Skills this agent can use                                                                                                                                          |
+| `hooks`           | object             | no       | [Hooks configuration](/api/schemas/hooks)                                                                                                                          |
+| `memory`          | string             | no       | `user`, `project`, or `local`                                                                                                                                      |
+| `effort`          | string             | no       | [Effort level](/api/schemas#effort-levels): `low`, `medium`, `high`, `xhigh`, or `max`                                                                             |
+| `maxTurns`        | number             | no       | Maximum agent turns (positive integer)                                                                                                                             |
+| `mcpServers`      | (string\|object)[] | no       | MCP server references or inline definitions                                                                                                                        |
+| `color`           | string             | no       | [Display color](/api/schemas#agent-colors): `red`, `blue`, `green`, `yellow`, `purple`, `orange`, `pink`, or `cyan`                                                |
+| `background`      | boolean            | no       | Run as background task (default: `false`)                                                                                                                          |
+| `isolation`       | string             | no       | `worktree` — run in a temporary git worktree                                                                                                                       |
+| `initialPrompt`   | string             | no       | Auto-submitted as the first user turn when this agent runs as the main session agent (via `--agent` or the `agent` setting). Prepended to any user-provided prompt |
 
-**Cross-field validations:**
+**Combining `tools` and `disallowedTools`:**
 
-- `tools` and `disallowedTools` are mutually exclusive
+Both may be set. `disallowedTools` is applied first, then `tools` is resolved against the
+remaining pool; a tool listed in both is removed.
 
 ## Example
 

--- a/website/api/schemas/hooks.md
+++ b/website/api/schemas/hooks.md
@@ -1,5 +1,5 @@
 ---
-description: "Schema reference for hooks.json configuration including events, matchers, and handler types."
+description: 'Schema reference for hooks.json configuration including events, matchers, and handler types.'
 ---
 
 # Hooks Configuration
@@ -15,39 +15,40 @@ Hooks run commands or prompts in response to Claude Code events. Each key is a [
 
 Top-level hooks object (standalone `hooks.json`):
 
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `description` | string | no | Human-readable description |
-| `hooks` | object | yes | Event-keyed hooks configuration |
+| Field         | Type   | Required | Description                     |
+| ------------- | ------ | -------- | ------------------------------- |
+| `description` | string | no       | Human-readable description      |
+| `hooks`       | object | yes      | Event-keyed hooks configuration |
 
 ## Hook Matcher
 
 Each event maps to an array of matcher objects:
 
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `matcher` | string | no | Pattern to match against (e.g., tool name for PreToolUse) |
-| `hooks` | object[] | yes | Array of [hook handlers](#hook-handler) |
+| Field     | Type     | Required | Description                                               |
+| --------- | -------- | -------- | --------------------------------------------------------- |
+| `matcher` | string   | no       | Pattern to match against (e.g., tool name for PreToolUse) |
+| `hooks`   | object[] | yes      | Array of [hook handlers](#hook-handler)                   |
 
 ## Hook Handler
 
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `type` | string | yes | `command`, `http`, `mcp_tool`, `prompt`, or `agent` ([valid values](/api/schemas#hook-types)) |
-| `command` | string | no | Shell command (when type is `command`) |
-| `url` | string | no | POST endpoint URL (when type is `http`) |
-| `headers` | object | no | HTTP headers (when type is `http`) |
-| `allowedEnvVars` | string[] | no | Env vars allowed in header interpolation (when type is `http`) |
-| `server` | string | no | MCP server name (when type is `mcp_tool`); server must already be connected |
-| `tool` | string | no | Tool name on the MCP server (when type is `mcp_tool`) |
-| `input` | object | no | Arguments passed to the tool (when type is `mcp_tool`); supports `${path}` substitution |
-| `prompt` | string | no | Prompt text (when type is `prompt` or `agent`) |
-| `agent` | string | no | Agent name (when type is `agent`) |
-| `timeout` | number | no | Timeout in seconds |
-| `statusMessage` | string | no | Status message shown during execution |
-| `once` | boolean | no | Run only once per session |
-| `model` | string | no | Model override for prompt/agent hooks |
-| `async` | boolean | no | Run hook asynchronously (non-blocking) |
+| Field            | Type     | Required | Description                                                                                                           |
+| ---------------- | -------- | -------- | --------------------------------------------------------------------------------------------------------------------- |
+| `type`           | string   | yes      | `command`, `http`, `mcp_tool`, `prompt`, or `agent` ([valid values](/api/schemas#hook-types))                         |
+| `command`        | string   | no       | Shell command (when type is `command`)                                                                                |
+| `url`            | string   | no       | POST endpoint URL (when type is `http`)                                                                               |
+| `headers`        | object   | no       | HTTP headers (when type is `http`)                                                                                    |
+| `allowedEnvVars` | string[] | no       | Env vars allowed in header interpolation (when type is `http`)                                                        |
+| `server`         | string   | no       | MCP server name (when type is `mcp_tool`); server must already be connected                                           |
+| `tool`           | string   | no       | Tool name on the MCP server (when type is `mcp_tool`)                                                                 |
+| `input`          | object   | no       | Arguments passed to the tool (when type is `mcp_tool`); supports `${path}` substitution                               |
+| `prompt`         | string   | no       | Prompt text. Required when type is `prompt` or `agent` — an agent hook is driven by `prompt`, not by an `agent` field |
+| `subagent_type`  | string   | no       | Type of specialized agent to use (when type is `agent`)                                                               |
+| `description`    | string   | no       | Short description of the task (when type is `agent`)                                                                  |
+| `timeout`        | number   | no       | Timeout in seconds                                                                                                    |
+| `statusMessage`  | string   | no       | Status message shown during execution                                                                                 |
+| `once`           | boolean  | no       | Run only once per session                                                                                             |
+| `model`          | string   | no       | Model override for prompt/agent hooks                                                                                 |
+| `async`          | boolean  | no       | Run hook asynchronously (non-blocking)                                                                                |
 
 ## Example
 

--- a/website/api/schemas/mcp.md
+++ b/website/api/schemas/mcp.md
@@ -1,5 +1,5 @@
 ---
-description: "Schema reference for .mcp.json MCP server configuration including all transport types."
+description: 'Schema reference for .mcp.json MCP server configuration including all transport types.'
 ---
 
 # MCP Configuration
@@ -19,38 +19,46 @@ Server configuration varies by [transport type](/api/schemas#mcp-transport-types
 
 Default transport when `command` is present.
 
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `type` | string | no | Optional, inferred from `command` |
-| `command` | string | yes | Command to execute |
-| `args` | string[] | no | Command arguments |
-| `env` | object | no | Environment variables |
+| Field     | Type     | Required | Description                       |
+| --------- | -------- | -------- | --------------------------------- |
+| `type`    | string   | no       | Optional, inferred from `command` |
+| `command` | string   | yes      | Command to execute                |
+| `args`    | string[] | no       | Command arguments                 |
+| `env`     | object   | no       | Environment variables             |
 
 ### http
 
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `type` | string | yes | Must be `"http"` |
-| `url` | string | yes | HTTP endpoint URL |
-| `headers` | object | no | HTTP headers |
-| `env` | object | no | Environment variables |
+| Field     | Type   | Required | Description           |
+| --------- | ------ | -------- | --------------------- |
+| `type`    | string | yes      | Must be `"http"`      |
+| `url`     | string | yes      | HTTP endpoint URL     |
+| `headers` | object | no       | HTTP headers          |
+| `env`     | object | no       | Environment variables |
 
 ### sse (deprecated)
 
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `type` | string | yes | Must be `"sse"` |
-| `url` | string | yes | SSE endpoint URL |
-| `headers` | object | no | HTTP headers |
-| `env` | object | no | Environment variables |
+| Field     | Type   | Required | Description           |
+| --------- | ------ | -------- | --------------------- |
+| `type`    | string | yes      | Must be `"sse"`       |
+| `url`     | string | yes      | SSE endpoint URL      |
+| `headers` | object | no       | HTTP headers          |
+| `env`     | object | no       | Environment variables |
 
-### websocket
+### ws (WebSocket)
 
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `type` | string | yes | Must be `"websocket"` |
-| `url` | string | yes | WebSocket URL |
-| `env` | object | no | Environment variables |
+The config literal is `"ws"` — not `"websocket"`, which is not a valid value.
+
+| Field     | Type   | Required | Description                                     |
+| --------- | ------ | -------- | ----------------------------------------------- |
+| `type`    | string | yes      | Must be `"ws"`                                  |
+| `url`     | string | yes      | WebSocket URL (`ws://` or `wss://`)             |
+| `headers` | object | no       | Request headers (WebSocket auth is header-only) |
+| `env`     | object | no       | Environment variables                           |
+
+### streamable-http
+
+A documented alias for `http`, accepted so configurations copied from MCP server
+documentation work unmodified. Same fields as `http`.
 
 ## Example
 

--- a/website/api/schemas/skills.md
+++ b/website/api/schemas/skills.md
@@ -1,5 +1,5 @@
 ---
-description: "Schema reference for SKILL.md YAML frontmatter fields, types, and constraints."
+description: 'Schema reference for SKILL.md YAML frontmatter fields, types, and constraints.'
 ---
 
 # SKILL.md Frontmatter
@@ -13,29 +13,25 @@ Skills are defined as `SKILL.md` files in skill directories. The YAML frontmatte
 
 ## Fields
 
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `name` | string | yes | Lowercase with hyphens, max 64 chars, no reserved words (`anthropic`, `claude`) |
-| `description` | string | yes | Min 10 chars, third-person voice |
-| `when_to_use` | string | no | Additional context for when Claude should invoke the skill (trigger phrases, examples). Appended to `description` in the skill listing |
-| `argument-hint` | string | no | Hint text shown during autocomplete (e.g., `[issue-number]`) |
-| `arguments` | string \| string[] | no | Named positional arguments for `$name` substitution. Accepts a space-separated string or YAML list |
-| `disable-model-invocation` | boolean | no | Prevent model from invoking this skill |
-| `user-invocable` | boolean | no | Whether users can invoke directly via `/skill-name` |
-| `version` | string | no | Semantic version (e.g., `1.0.0`) (claudelint extension) |
-| `model` | string | no | `sonnet`, `opus`, `haiku`, or `inherit` ([valid values](/api/schemas#model-names)) |
-| `effort` | string | no | [Effort level](/api/schemas#effort-levels): `low`, `medium`, `high`, `xhigh`, or `max` |
-| `context` | string | no | `fork` ([valid values](/api/schemas#context-modes)) |
-| `agent` | string | no | Agent name (required when `context: fork`) |
-| `allowed-tools` | string \| string[] | no | [Tool names](/api/schemas#tool-names) to allow. Accepts a space-separated string or YAML list |
-| `paths` | string \| string[] | no | Glob patterns that limit when this skill is auto-activated. Accepts a comma-separated string or YAML list |
-| `shell` | string | no | Shell to use for inline `` !`command` `` blocks: `bash` (default) or `powershell` |
-| `tags` | string[] | no | Categorization tags (claudelint extension) |
-| `hooks` | object | no | [Hooks configuration](/api/schemas/hooks) |
-
-**Cross-field validations:**
-
-- When `context` is `fork`, the `agent` field is required
+| Field                      | Type               | Required | Description                                                                                                                            |
+| -------------------------- | ------------------ | -------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| `name`                     | string             | yes      | Lowercase with hyphens, max 64 chars, no reserved words (`anthropic`, `claude`)                                                        |
+| `description`              | string             | yes      | Min 10 chars, third-person voice                                                                                                       |
+| `when_to_use`              | string             | no       | Additional context for when Claude should invoke the skill (trigger phrases, examples). Appended to `description` in the skill listing |
+| `argument-hint`            | string             | no       | Hint text shown during autocomplete (e.g., `[issue-number]`)                                                                           |
+| `arguments`                | string \| string[] | no       | Named positional arguments for `$name` substitution. Accepts a space-separated string or YAML list                                     |
+| `disable-model-invocation` | boolean            | no       | Prevent model from invoking this skill                                                                                                 |
+| `user-invocable`           | boolean            | no       | Whether users can invoke directly via `/skill-name`                                                                                    |
+| `version`                  | string             | no       | Semantic version (e.g., `1.0.0`) (claudelint extension)                                                                                |
+| `model`                    | string             | no       | `sonnet`, `opus`, `haiku`, or `inherit` ([valid values](/api/schemas#model-names))                                                     |
+| `effort`                   | string             | no       | [Effort level](/api/schemas#effort-levels): `low`, `medium`, `high`, `xhigh`, or `max`                                                 |
+| `context`                  | string             | no       | `fork` ([valid values](/api/schemas#context-modes))                                                                                    |
+| `agent`                    | string             | no       | Which subagent type to use when `context: fork` is set                                                                                 |
+| `allowed-tools`            | string \| string[] | no       | [Tool names](/api/schemas#tool-names) to allow. Accepts a space-separated string or YAML list                                          |
+| `paths`                    | string \| string[] | no       | Glob patterns that limit when this skill is auto-activated. Accepts a comma-separated string or YAML list                              |
+| `shell`                    | string             | no       | Shell to use for inline `` !`command` `` blocks: `bash` (default) or `powershell`                                                      |
+| `tags`                     | string[]           | no       | Categorization tags (claudelint extension)                                                                                             |
+| `hooks`                    | object             | no       | [Hooks configuration](/api/schemas/hooks)                                                                                              |
 
 ## Example
 

--- a/website/rules/mcp/mcp-invalid-transport.md
+++ b/website/rules/mcp/mcp-invalid-transport.md
@@ -8,7 +8,7 @@ description: "MCP transport type must be one of the supported values"
 
 ## Rule Details
 
-This rule checks that the type field of each MCP server is one of the supported transport types: stdio, sse, http, or websocket. An unrecognized transport type will prevent Claude Code from establishing a connection to the MCP server. Servers without an explicit type field are skipped because the type can be inferred from the presence of a command field.
+This rule checks that the type field of each MCP server is one of the supported transport types: stdio, sse, http, streamable-http, or ws. An unrecognized transport type will prevent Claude Code from establishing a connection to the MCP server. Servers without an explicit type field are skipped because the type can be inferred from the presence of a command field.
 
 ### Incorrect
 
@@ -56,7 +56,7 @@ Server with a valid stdio transport type
 
 ## How To Fix
 
-Change the type field to one of the supported values: stdio, sse, http, or websocket. Note that sse is deprecated in favor of http.
+Change the type field to one of the supported values: stdio, sse, http, streamable-http, or ws. Note that sse is deprecated in favor of http, and that the WebSocket literal is "ws" - not "websocket", which is not a valid config value.
 
 ## Options
 

--- a/website/rules/mcp/mcp-sse-transport-deprecated.md
+++ b/website/rules/mcp/mcp-sse-transport-deprecated.md
@@ -46,7 +46,7 @@ Server using WebSocket transport
 {
   "mcpServers": {
     "remote": {
-      "type": "websocket",
+      "type": "ws",
       "url": "wss://mcp.example.com/ws"
     }
   }

--- a/website/rules/mcp/mcp-websocket-empty-url.md
+++ b/website/rules/mcp/mcp-websocket-empty-url.md
@@ -18,7 +18,7 @@ WebSocket server with an empty URL string
 {
   "mcpServers": {
     "realtime": {
-      "type": "websocket",
+      "type": "ws",
       "url": ""
     }
   }
@@ -31,7 +31,7 @@ WebSocket server with the url field missing
 {
   "mcpServers": {
     "realtime": {
-      "type": "websocket"
+      "type": "ws"
     }
   }
 }
@@ -45,7 +45,7 @@ WebSocket server with a valid URL
 {
   "mcpServers": {
     "realtime": {
-      "type": "websocket",
+      "type": "ws",
       "url": "wss://mcp.example.com/ws"
     }
   }

--- a/website/rules/mcp/mcp-websocket-invalid-protocol.md
+++ b/website/rules/mcp/mcp-websocket-invalid-protocol.md
@@ -18,7 +18,7 @@ WebSocket server using https:// instead of wss://
 {
   "mcpServers": {
     "realtime": {
-      "type": "websocket",
+      "type": "ws",
       "url": "https://mcp.example.com/ws"
     }
   }
@@ -33,7 +33,7 @@ WebSocket server using wss:// protocol
 {
   "mcpServers": {
     "realtime": {
-      "type": "websocket",
+      "type": "ws",
       "url": "wss://mcp.example.com/ws"
     }
   }
@@ -46,7 +46,7 @@ WebSocket server using ws:// protocol for local development
 {
   "mcpServers": {
     "local": {
-      "type": "websocket",
+      "type": "ws",
       "url": "ws://localhost:8080/ws"
     }
   }

--- a/website/rules/mcp/mcp-websocket-invalid-url.md
+++ b/website/rules/mcp/mcp-websocket-invalid-url.md
@@ -18,7 +18,7 @@ WebSocket server with a malformed URL
 {
   "mcpServers": {
     "realtime": {
-      "type": "websocket",
+      "type": "ws",
       "url": "not-a-valid-url"
     }
   }
@@ -33,7 +33,7 @@ WebSocket server with a valid URL
 {
   "mcpServers": {
     "realtime": {
-      "type": "websocket",
+      "type": "ws",
       "url": "wss://mcp.example.com/ws"
     }
   }
@@ -46,7 +46,7 @@ WebSocket server with a variable-expanded URL (skipped)
 {
   "mcpServers": {
     "realtime": {
-      "type": "websocket",
+      "type": "ws",
       "url": "${MCP_WS_URL}"
     }
   }


### PR DESCRIPTION
Release prep. The schema work in #136–#143 changed what claudelint accepts; the **user-facing docs still described the old behavior**, and in several places told users to write config that Claude Code rejects.

## Docs that were actively wrong

| Page | Said | Reality |
|---|---|---|
| 4 MCP rule pages | examples using `"type": "websocket"` | not a valid config value |
| `mcp-invalid-transport` | supported transports are "stdio, sse, http, or **websocket**" | `stdio`, `sse`, `http`, `streamable-http`, `ws` |
| `api/schemas/mcp.md` | a `websocket` transport section | the literal is `ws`; `streamable-http` was undocumented |
| `api/schemas/agents.md` | `tools`/`disallowedTools` are **mutually exclusive**; both `string[]` | not exclusive (docs define combined behavior); both accept a comma-separated string too; `manual` missing from permissionMode |
| `api/schemas/skills.md` | `agent` is **required** when `context: fork` | it is not |
| `api/schemas/hooks.md` | an `agent` field on agent hooks | no such field — an agent hook is driven by `prompt` |

The MCP rule examples are the notable one: Phase 1 (#136) updated the rules' **prose** but its `sed` missed the examples' escaping, so the generated pages kept advertising the phantom literal. The rule source is the generator's input, so the fix is there and the pages regenerate from it.

## Audit doc retired

`docs/projects/upstream-drift-audit.md` is marked **RESOLVED** — with what it found, what shipped, and, more usefully, **the three things it got wrong**, so a future sweep doesn't repeat them:

- Severity 1.3 (skill `name` required) **does not reproduce** — read off the Zod declaration, never exercised against the CLI.
- **`enableWeakerNestedSandbox` was never cleared, and it is documented.** It fits the hallucination pattern exactly; deleting it on that basis would have repeated the `disallowed-tools` mistake the document itself flags.
- **The method could not see type drift.** A field-name diff calls `tools` conformant while the docs' own canonical sub-agent fails to lint.

## Testing

- 2093 tests green; `check:schema-docs`, `check:schema-docs-coverage`, `check:all`, `lint:md`, `docs:build` — green
- Reverted prettier's table-realignment churn on five schema pages I didn't touch, to keep the diff reviewable

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RLcJgHCxxsifDhJck6C8xb