### PR TITLE
fix: accept documented `fable` model and `pathPattern` marketplace source

### DIFF
--- a/schemas/skill-frontmatter.schema.json
+++ b/schemas/skill-frontmatter.schema.json
@@ -85,7 +85,7 @@
     "model": {
       "type": "string",
       "description": "Model to use when this skill is active.",
-      "enum": ["sonnet", "opus", "haiku", "inherit"]
+      "enum": ["sonnet", "opus", "haiku", "fable", "inherit"]
     },
     "context": {
       "type": "string",

--- a/src/rules/agents/agent-model.ts
+++ b/src/rules/agents/agent-model.ts
@@ -10,8 +10,13 @@
 import { Rule, RuleContext } from '../../types/rule';
 import { extractFrontmatter, getFrontmatterFieldLine } from '../../utils/formats/markdown';
 
-/** Known model aliases */
-const MODEL_ALIASES = ['sonnet', 'opus', 'haiku', 'inherit'];
+/**
+ * Known model aliases
+ *
+ * docs-baseline/sub-agents.md:290 — "use one of the available aliases: `sonnet`,
+ * `opus`, `haiku`, or `fable`". `inherit` is documented alongside them at :273.
+ */
+const MODEL_ALIASES = ['sonnet', 'opus', 'haiku', 'fable', 'inherit'];
 
 /** Pattern for full Claude model IDs (e.g. claude-sonnet-4-5, claude-opus-4-6) */
 const FULL_MODEL_ID_RE = /^claude-[a-z]+-[\d]+-[\d]+/;

--- a/src/schemas/constants.ts
+++ b/src/schemas/constants.ts
@@ -39,8 +39,11 @@ export const ToolNames = z.enum([
 
 /**
  * Valid Claude model names
+ *
+ * docs-baseline/sub-agents.md:290 — "use one of the available aliases: `sonnet`,
+ * `opus`, `haiku`, or `fable`". `inherit` is documented alongside them at :273.
  */
-export const ModelNames = z.enum(['sonnet', 'opus', 'haiku', 'inherit']);
+export const ModelNames = z.enum(['sonnet', 'opus', 'haiku', 'fable', 'inherit']);
 
 /**
  * Valid permission action types

--- a/src/validators/schemas.ts
+++ b/src/validators/schemas.ts
@@ -231,16 +231,32 @@ export const MarketplaceConfigSchema = z.object({
 /**
  * Strict marketplace source schema for settings (strictKnownMarketplaces)
  * Based on: https://code.claude.com/docs/en/settings#strictknownmarketplaces
- * Same source types as extraKnownMarketplaces plus hostPattern for regex matching
+ *
+ * Same source types as extraKnownMarketplaces, plus the two regex-matching sources.
+ * docs-baseline/settings.md:872 — "Most sources use exact matching, while `hostPattern`
+ * and `pathPattern` use regex matching against the marketplace host and filesystem path
+ * respectively."
  */
 export const StrictMarketplaceSourceSchema = z.object({
-  source: z.enum(['github', 'git', 'url', 'npm', 'directory', 'file', 'hostPattern']),
+  source: z.enum([
+    'github',
+    'git',
+    'url',
+    'npm',
+    'directory',
+    'file',
+    'hostPattern',
+    'pathPattern',
+  ]),
   repo: z.string().optional(),
   url: z.string().optional(),
   package: z.string().optional(),
   path: z.string().optional(),
   ref: z.string().optional(),
   hostPattern: z.string().optional(), // regex pattern for hostPattern source
+  // docs-baseline/settings.md:959 — "Fields: `pathPattern` (required: regex pattern
+  // matched against the `path` field of `file` and `directory` sources)"
+  pathPattern: z.string().optional(),
 });
 
 /**

--- a/tests/rules/agents/agent-model.test.ts
+++ b/tests/rules/agents/agent-model.test.ts
@@ -28,6 +28,12 @@ describe('agent-model', () => {
             '---\nname: my-agent\ndescription: Test agent\nmodel: claude-opus-4-6\n---\n# Agent',
           filePath: '/test/agents/AGENT.md',
         },
+        // docs-baseline/sub-agents.md:290 lists the aliases as
+        // "sonnet, opus, haiku, or fable"
+        {
+          content: '---\nname: my-agent\ndescription: Test agent\nmodel: fable\n---\n# Agent',
+          filePath: '/test/agents/AGENT.md',
+        },
       ],
 
       invalid: [

--- a/tests/rules/skills/skill-model.test.ts
+++ b/tests/rules/skills/skill-model.test.ts
@@ -24,6 +24,12 @@ describe('skill-model', () => {
           content: '---\nname: my-skill\ndescription: Test skill\nmodel: opus\n---\n# Skill',
           filePath: '/test/SKILL.md',
         },
+        // docs-baseline/sub-agents.md:290 lists the aliases as
+        // "sonnet, opus, haiku, or fable"
+        {
+          content: '---\nname: my-skill\ndescription: Test skill\nmodel: fable\n---\n# Skill',
+          filePath: '/test/SKILL.md',
+        },
         // No model field (optional)
         {
           content: '---\nname: my-skill\ndescription: Test skill\n---\n# Skill',

--- a/tests/schemas/constants.test.ts
+++ b/tests/schemas/constants.test.ts
@@ -54,6 +54,8 @@ describe('Schema Constants', () => {
       expect(ModelNames.safeParse('sonnet').success).toBe(true);
       expect(ModelNames.safeParse('opus').success).toBe(true);
       expect(ModelNames.safeParse('haiku').success).toBe(true);
+      // docs-baseline/sub-agents.md:290 — "sonnet, opus, haiku, or fable"
+      expect(ModelNames.safeParse('fable').success).toBe(true);
       expect(ModelNames.safeParse('inherit').success).toBe(true);
     });
 
@@ -64,7 +66,7 @@ describe('Schema Constants', () => {
     });
 
     it('should export runtime values', () => {
-      expect(VALID_MODELS).toEqual(['sonnet', 'opus', 'haiku', 'inherit']);
+      expect(VALID_MODELS).toEqual(['sonnet', 'opus', 'haiku', 'fable', 'inherit']);
     });
   });
 

--- a/tests/schemas/settings.schema.test.ts
+++ b/tests/schemas/settings.schema.test.ts
@@ -542,6 +542,31 @@ describe('SettingsSchema — the documented surface', () => {
     }
   });
 
+  it('accepts every documented strictKnownMarketplaces source type', () => {
+    // docs-baseline/settings.md:872 — "The allowlist supports multiple marketplace source
+    // types. Most sources use exact matching, while `hostPattern` and `pathPattern` use
+    // regex matching against the marketplace host and filesystem path respectively."
+    //
+    // `pathPattern` was missing from the enum, so the documented example at
+    // settings.md:955 — { "source": "pathPattern", "pathPattern": "^/opt/approved/" } —
+    // was rejected with "Invalid option".
+    const documentedSources = [
+      { source: 'github', repo: 'owner/repo' },
+      { source: 'git', url: 'https://example.com/x.git' },
+      { source: 'url', url: 'https://example.com/m.json' },
+      { source: 'npm', package: '@scope/pkg' },
+      { source: 'directory', path: '/opt/approved' },
+      { source: 'file', path: '/opt/approved/m.json' },
+      { source: 'hostPattern', hostPattern: '^github\\.com$' },
+      { source: 'pathPattern', pathPattern: '^/opt/approved/' },
+    ];
+
+    for (const entry of documentedSources) {
+      const result = SettingsSchema.safeParse({ strictKnownMarketplaces: [entry] });
+      expect(result.success).toBe(true);
+    }
+  });
+
   it('does NOT model the global config keys, which belong in ~/.claude.json', () => {
     // "These settings are stored in `~/.claude.json` rather than `settings.json`. Adding
     // them to `settings.json` will trigger a schema validation error." Modelling them here

--- a/website/api/schemas/settings.md
+++ b/website/api/schemas/settings.md
@@ -34,16 +34,31 @@ The `settings.json` file configures Claude Code behavior. It can be located at `
 
 ### Sandbox
 
-| Field                       | Type     | Required | Description                      |
-| --------------------------- | -------- | -------- | -------------------------------- |
-| `enabled`                   | boolean  | no       | Enable sandboxing                |
-| `autoAllowBashIfSandboxed`  | boolean  | no       | Auto-allow bash in sandbox       |
-| `excludedCommands`          | string[] | no       | Commands excluded from sandbox   |
-| `allowUnsandboxedCommands`  | string[] | no       | Commands allowed outside sandbox |
-| `network.allowedHosts`      | string[] | no       | Allowed network hosts            |
-| `network.allowedPorts`      | number[] | no       | Allowed network ports            |
-| `enableWeakerNestedSandbox` | boolean  | no       | Allow weaker nested sandbox      |
-| `ignoreViolations`          | boolean  | no       | Ignore sandbox violations        |
+| Field                       | Type     | Required | Description                                                  |
+| --------------------------- | -------- | -------- | ------------------------------------------------------------ |
+| `enabled`                   | boolean  | no       | Enable sandboxing                                            |
+| `failIfUnavailable`         | boolean  | no       | Fail rather than run unsandboxed when the sandbox is missing |
+| `autoAllowBashIfSandboxed`  | boolean  | no       | Auto-allow bash in sandbox                                   |
+| `excludedCommands`          | string[] | no       | Commands excluded from sandbox                               |
+| `allowUnsandboxedCommands`  | boolean  | no       | Allow the `dangerouslyDisableSandbox` escape hatch           |
+| `enableWeakerNestedSandbox` | boolean  | no       | Allow weaker nested sandbox                                  |
+| `filesystem`                | object   | no       | Filesystem read/write allow and deny lists                   |
+| `credentials`               | object   | no       | Credential file and env var protection                       |
+| `network`                   | object   | no       | Network restrictions (see below)                             |
+
+### Sandbox network
+
+| Field                     | Type     | Required | Description                             |
+| ------------------------- | -------- | -------- | --------------------------------------- |
+| `allowedDomains`          | string[] | no       | Domains the sandbox may reach           |
+| `deniedDomains`           | string[] | no       | Domains the sandbox may not reach       |
+| `allowManagedDomainsOnly` | boolean  | no       | Restrict to managed domains             |
+| `allowUnixSockets`        | string[] | no       | Unix sockets the sandbox may connect to |
+| `allowAllUnixSockets`     | boolean  | no       | Allow all Unix sockets                  |
+| `allowLocalBinding`       | boolean  | no       | Allow binding to local ports            |
+| `allowMachLookup`         | string[] | no       | Mach services the sandbox may look up   |
+| `httpProxyPort`           | number   | no       | HTTP proxy port                         |
+| `socksProxyPort`          | number   | no       | SOCKS proxy port                        |
 
 ## Example
 


### PR DESCRIPTION
Two false positives left over from the #132 backlog, plus the docs regression that backlog's own work introduced. All three are cases of claudelint contradicting the committed baseline, so each change quotes the doc line it rests on.

## The two false positives

**`model: fable`** was rejected outright:

```text
4  error  Invalid option: expected one of "sonnet"|"opus"|"haiku"|"inherit"  skill-model
```

> `docs-baseline/sub-agents.md:290` — "use one of the available aliases: `sonnet`, `opus`, `haiku`, or `fable`"

Two independent copies of the alias list were stale: the `ModelNames` enum (feeding `skill-model`) and a hand-maintained duplicate inside `agent-model.ts`. Both fixed.

**`strictKnownMarketplaces` with `source: "pathPattern"`** was rejected with `Invalid option`, so the documented example could not be written at all:

> `docs-baseline/settings.md:955` — `{ "source": "pathPattern", "pathPattern": "^/opt/approved/" }`
> `docs-baseline/settings.md:872` — "`hostPattern` and `pathPattern` use regex matching against the marketplace host and filesystem path respectively"

`strictKnownMarketplaces` had no test coverage whatsoever; this adds a case asserting every documented source type parses.

## The docs regression

`website/api/schemas/settings.md` still advertised all three sandbox fields that #140 deleted **as hallucinations** (`network.allowedHosts`, `network.allowedPorts`, `ignoreViolations`), and still typed `allowUnsandboxedCommands` as `string[]` after #142 corrected it to a boolean.

So claudelint's own public docs were telling users to write config that Claude Code ignores — the exact failure #140 set out to end. #143 fixed this file's *Example* block but missed its *field table*. The table now matches the real schema shape.

## Why no gate caught any of this

Worth recording, because it is the same lesson as the rest of the backlog — each gate is blind to a different thing:

| Gate | Sees | Why it missed these |
|---|---|---|
| `check:upstream` | field **names** | `model` and `source` exist in both; the drift is in *accepted values* |
| docs-examples (#136) | whole **examples** | `fable` appears only in a prose alias list, never in an example |
| field-types (#141) | table **example values** | `pathPattern` appears only in a fenced fragment, not a table row |
| `check:schema-docs-coverage` | **Zod -> docs** only | the docs regression is docs -> Zod, a direction it never walks |

Making `check:schema-docs-coverage` bidirectional would have caught the regression, and is carried into the follow-up issue.

## Verification

- Both false positives reproduced against the built CLI before the fix and are gone after.
- Tests written first and confirmed red for the right reason.
- Full `npm run validate` green: 213 suites, 2094 tests.

Part of #132.